### PR TITLE
Fix REGEXP_SUBSTR2 to return a single value instead of an array

### DIFF
--- a/RegularExpressions/regexp2.sql
+++ b/RegularExpressions/regexp2.sql
@@ -45,7 +45,7 @@ $$
     }
     
     if (instr != -1) {
-        return str.match(regex);
+        return str.match(regex)[OCCURRENCE-1];
     } else {
         return "";
     }


### PR DESCRIPTION
The REGEXP_SUBSTR2 function doesn't correctly imitate the REGEXP_SUBSTR function on Snowflake because it returns the entire generated array, instead of a single occurrence. This fix selects the array element associated with the occurrence input.