### PR TITLE
Fix REGEXP_SUBSTR2 for lookbehind regex inputs

### DIFF
--- a/RegularExpressions/regexp2.sql
+++ b/RegularExpressions/regexp2.sql
@@ -40,7 +40,9 @@ $$
     for (i = 1; i <= OCCURRENCE; i++) {
         instr = str.search(regex);
         if (instr === -1) break;
-        str = str.substring(instr);  // Next iteration for occurrence
+        if (i != OCCURRENCE) { // No substring on final occurrence
+            str = str.substring(instr);  // Next iteration for occurrence
+        }
         cursor = cursor + instr + 1;
     }
     


### PR DESCRIPTION
Lookbehinds at the start of the regex input would break the REGEXP_SUBSTR2 function(s), because of taking a substring on the final loop. Taking a substring on the final loop is never necessary. This change fixes that issue.